### PR TITLE
Fix example in doeach to match the CL example.

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,7 +93,7 @@
                 <pre><code class="lisp">
 (doeach ((key val) *hash*)
   (when (&lt; (length key) 2)
-    (princ #"${x}\n")))
+    (princ #"${val}\n")))
                 </code></pre>
               </td>
               <td>


### PR DESCRIPTION
The interpolated x variable does not exist in this scope, its not the same as the common-lisp equivalent on the right, by princ'ing val (an in-scope-variable) and likely what the original author meant, this example is equivalent and should work.

I hope I understand the intent, if not, feel free to close this pull request.

Thanks.